### PR TITLE
reflow on superscript/subscript change (and some typescript)

### DIFF
--- a/src/commands/math.ts
+++ b/src/commands/math.ts
@@ -78,8 +78,9 @@ class MathElement extends MQNode {
   reflow() {
     // if element reflows, and right is supsub, that needs to reflow too
     // to recalculate layout
-    if (this[R] instanceof SupSub) {
-      this[R].reflow();
+    const right = this[R];
+    if (right instanceof SupSub) {
+      right.reflow();
     }
   }
 }

--- a/src/commands/math/commands.ts
+++ b/src/commands/math/commands.ts
@@ -362,8 +362,11 @@ class SupSub extends MathCommand {
           var src = this[supsub],
             dest = thisDir[supsub];
           if (!src) continue;
-          if (!dest) thisDir.addBlock(src.disown());
-          else if (!src.isEmpty()) {
+          if (!dest) {
+            thisDir.addBlock(src.disown());
+            src.blur(cursor);
+            thisDir.reflow();
+          } else if (!src.isEmpty()) {
             // ins src children at -dir end of dest
             src
               .domFrag()
@@ -530,6 +533,7 @@ class SupSub extends MathCommand {
             cmd.domFrag().addClass('mq-sup-only').children().last().remove();
           }
           this.remove();
+          cmd.reflow();
         };
       })(
         this,
@@ -539,8 +543,9 @@ class SupSub extends MathCommand {
       );
   }
   reflow() {
-    if (this[L] && this.blocks) {
-      const base = this[L].domFrag().oneElement();
+    const left = this[L];
+    if (left && this.blocks) {
+      const base = left.domFrag().oneElement();
       const supsub = this.domFrag().oneElement();
       supsub.style.verticalAlign = '0px';
       const baseRect = base.getBoundingClientRect();

--- a/test/tsconfig.public-types-test.json
+++ b/test/tsconfig.public-types-test.json
@@ -12,6 +12,7 @@
       "target": "ES5",
       "lib": ["ES5", "ScriptHost", "DOM", "ES2015.Collection"],
       "module": "ES2015",
+      "moduleResolution": "node",
       "importHelpers": true,
       "noEmit": true,
       "pretty": true


### PR DESCRIPTION
* Added empty block styling to ensure correct bounding box computation for superscript and subscript nodes that were just added
* Called reflow on changes from superscript only/subscript only to both combined and vice versa
* Changed some TypeScript errors